### PR TITLE
Obtain link href via event so you get full url

### DIFF
--- a/lib/browser-inject.js
+++ b/lib/browser-inject.js
@@ -73,7 +73,7 @@ module.exports = function(el) {
   delegate.on('click', 'a', function(e, target) {
     // Ignore links with a target.
     if(!target.hasAttribute("target")) {
-      var url    = target.getAttribute("href");
+      var url    = e.target.href;
       var ret    = router.go(url, "get");
 
       if(ret) {


### PR DESCRIPTION
use e.target.href instead of target.getAttribute(href) as it constructs full urls from input such as ?fish=badger
