### PR TITLE
better url normalisation

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -1,4 +1,4 @@
-var url          = require("url");
+var Url          = require("url");
 var pathToRegexp = require('path-to-regexp');
 var browserEnv   = require("./lib/browser-inject");
 var historyEnv   = require("./lib/history");
@@ -52,7 +52,7 @@ function handler(method, path, fn, next) {
   var keys = re.keys;
 
   this.routes.push(function(_path, _method, req, res) {
-    var pathname = url.parse(_path).pathname;
+    var pathname = Url.parse(_path).pathname;
 
     if(method !== "use" && method !== _method) {
       return false;
@@ -70,7 +70,7 @@ function handler(method, path, fn, next) {
 
     req.params = params;
 
-    var urlParsed = url.parse(_path, true);
+    var urlParsed = Url.parse(_path, true);
 
     req.path  = urlParsed.pathname;
     req.query = urlParsed.query;

--- a/lib/browser-inject.js
+++ b/lib/browser-inject.js
@@ -27,6 +27,41 @@ function getFormData(el) {
   return out;
 }
 
+/**
+ * make a url from an href or action attribute into a url isoRouter can handle
+ *
+ * If clicking a link on a page hosted at /land?animal=badger#grass
+ *
+ * If a host or pathname there is enough to route
+ * /sea                    -> /sea
+ * /sea#weed               -> /sea#weed
+ * /sea?fish=flounder      -> /sea?fish=flounder
+ * /sea?fish=flounder#weed -> /sea?fish=flounder#weed
+ *
+ * If only a search query is given it is intended to be relative to the current path
+ * ?fish=flounder          -> /land?fish=flounder
+ * ?fish=flounder#weed     -> /land?fish=flounder#weed
+ *
+ * If only a hash is given it is intended to be relative to the current search query
+ * #sea                    -> /land?animal=badger#sea
+ *
+ * @param {String}  url     input url to normalize
+ * @returns {String} normalized url ensuring hash, search and path are appropriate
+ */
+function tidyUrl(url) {
+  var urlParsed = Url.parse(url, true);
+
+  if (!urlParsed.host && !urlParsed.pathname) {
+    urlParsed.pathname = window.location.pathname;
+
+    if (urlParsed.hash && !urlParsed.search) {
+      urlParsed.search = window.location.search;
+    }
+  }
+
+  return Url.format(urlParsed);
+}
+
 module.exports = function(el) {
   var router = this;
 
@@ -57,14 +92,14 @@ module.exports = function(el) {
   }
 
   delegate.on('submit', 'form', function(e, target) {
-    var url    = target.getAttribute("action");
+    var url = tidyUrl(target.getAttribute("action"));
     var method = target.getAttribute("method");
     submit(method, url, target)
     e.preventDefault();
   });
 
   delegate.on('click', 'input[formaction]', function(e, target) {
-    var url    = target.getAttribute("formaction");
+    var url = tidyUrl(target.getAttribute("formaction"));
     var method = target.getAttribute("formmethod");
     submit(method, url, target)
     e.preventDefault();
@@ -73,8 +108,8 @@ module.exports = function(el) {
   delegate.on('click', 'a', function(e, target) {
     // Ignore links with a target.
     if(!target.hasAttribute("target")) {
-      var url    = e.target.href;
-      var ret    = router.go(url, "get");
+      var url = tidyUrl(target.getAttribute("href"));
+      var ret = router.go(url, "get");
 
       if(ret) {
         e.preventDefault();

--- a/lib/browser-inject.js
+++ b/lib/browser-inject.js
@@ -27,41 +27,6 @@ function getFormData(el) {
   return out;
 }
 
-/**
- * make a url from an href or action attribute into a url isoRouter can handle
- *
- * If clicking a link on a page hosted at /land?animal=badger#grass
- *
- * If a host or pathname there is enough to route
- * /sea                    -> /sea
- * /sea#weed               -> /sea#weed
- * /sea?fish=flounder      -> /sea?fish=flounder
- * /sea?fish=flounder#weed -> /sea?fish=flounder#weed
- *
- * If only a search query is given it is intended to be relative to the current path
- * ?fish=flounder          -> /land?fish=flounder
- * ?fish=flounder#weed     -> /land?fish=flounder#weed
- *
- * If only a hash is given it is intended to be relative to the current search query
- * #sea                    -> /land?animal=badger#sea
- *
- * @param {String}  url     input url to normalize
- * @returns {String} normalized url ensuring hash, search and path are appropriate
- */
-function tidyUrl(url) {
-  var urlParsed = Url.parse(url, true);
-
-  if (!urlParsed.host && !urlParsed.pathname) {
-    urlParsed.pathname = window.location.pathname;
-
-    if (urlParsed.hash && !urlParsed.search) {
-      urlParsed.search = window.location.search;
-    }
-  }
-
-  return Url.format(urlParsed);
-}
-
 module.exports = function(el) {
   var router = this;
 
@@ -79,12 +44,21 @@ module.exports = function(el) {
     var data = getFormData(target);
 
     var urlParsed = Url.parse(url, true);
-    if(urlParsed.query && urlParsed.query._method) {
-      method = urlParsed.query._method;
+    if(data._method || urlParsed.query && urlParsed.query._method) {
+      method = data._method || urlParsed.query._method;
     }
 
     if(method === "get") {
-      url = url + "?" + Qs.stringify(data);
+      // Combine form data and url data taking form data in precidence
+      if (urlParsed.query) {
+        Object.keys(urlParsed.query).forEach(function (key) {
+          data[key] = data[key] || urlParsed.query[key];
+        });
+      }
+      url = Url.format({
+        pathname: urlParsed.pathname,
+        query: data
+      })
       router.go(url, method, false);
     } else {
       router.go(url, method, false, data);
@@ -92,14 +66,14 @@ module.exports = function(el) {
   }
 
   delegate.on('submit', 'form', function(e, target) {
-    var url = tidyUrl(target.getAttribute("action"));
+    var url = target.getAttribute("action");
     var method = target.getAttribute("method");
     submit(method, url, target)
     e.preventDefault();
   });
 
   delegate.on('click', 'input[formaction]', function(e, target) {
-    var url = tidyUrl(target.getAttribute("formaction"));
+    var url = target.getAttribute("formaction");
     var method = target.getAttribute("formmethod");
     submit(method, url, target)
     e.preventDefault();
@@ -108,8 +82,8 @@ module.exports = function(el) {
   delegate.on('click', 'a', function(e, target) {
     // Ignore links with a target.
     if(!target.hasAttribute("target")) {
-      var url = tidyUrl(target.getAttribute("href"));
-      var ret = router.go(url, "get");
+      var url    = target.getAttribute("href");
+      var ret    = router.go(url, "get");
 
       if(ret) {
         e.preventDefault();


### PR DESCRIPTION
This is a better fix to what I was trying to do before.  Ran into problems with that if there were items nested into the link.

The href/action attributes when written into the tags are relative to the current url.

If a host is given it's absolute.
If a path is given it's relative to the host.
If a search is given it's relative to the host & pathname.
If a hash is given it's relative to the host, pathname and search.

This logic ensures that any relative urls are made isorouter compatible.
