### PR TITLE
perform normal navigation if router doesn't respond

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -103,7 +103,6 @@ function go(path, method, silent, body) {
 
   path = tidyUrl(path);
 
-  var ret = true;
   var req = {
     __id: uid++,
     body: body
@@ -119,16 +118,19 @@ function go(path, method, silent, body) {
     historyEnv.go(path);
   }
 
-  // Reset scroll position
-  window.scrollTo(0,0);
-
-  if(!ret) {
-    return false;
-  }
-  this.routes.some(function(fn) {
+  var isRouteFound = this.routes.some(function(fn) {
     return fn(path, method, req, res);
   });
-  return true;
+
+  if (isRouteFound) {
+    // Reset scroll position
+    window.scrollTo(0,0);
+
+    // return true to prevent default navigation
+    return true;
+  } else {
+    return false;
+  }
 }
 
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
   "devDependencies": {
     "body-parser": "^1.13.3",
     "browserify": "^11.0.1",
-    "express": "^4.13.3",
     "express-handlebars": "^2.0.1",
     "method-override": "^2.3.5",
     "mocha": "^2.2.4",


### PR DESCRIPTION
If isorouter doesn't respond to a request we can let the browser take over.  Useful for external links and even handling 404's easily
