### PR TITLE
Added option 'data-prevent-scroll-reset'

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,13 +5,13 @@ A router for both the client and the server with an express.js like API.
 
 ## How it works on the server
 
-`require("isorouter")` will return a vanilla express router. However, it should only be used with isorouter compliant methods to ensure code will be compatibile.
+`require("isorouter")` will return a vanilla express router. However, it should only be used with isorouter compliant methods to ensure code will be compatible.
 
 ## How it works on the browser
 
 When run on a client it is easiest to think of isorouter as mounting an express server into the browser itself. The browser provides the incoming requests to the router via the url (pushstate) which are handled in an express like manner.
 
-`require("isorouter")` will return an isoRouter. This mimics the functionality of express middleware and route matching.
+`require("isorouter")` will return an isorouter. This mimics the functionality of express middleware and route matching.
 
 To start the app trigger the first route with `router.go(window.location)`.
 
@@ -109,7 +109,7 @@ Removes all delegate and url listeners.
 Exports an object with functionality to manipulate push state history.
 
 * `go(url)` - go to a given url
-* `back()` - go the the previous page in push state (if present)
+* `back()` - go back to the previous page in push state (if present)
 * `forward()` - go to the next page in push state (if present)
 * `redirect(url, state)` - go to a url and replace the existing pushstate
 
@@ -147,7 +147,7 @@ Listen for DELETE on the server and form submissions on the client and trigger t
 
 ## Event handling
 
-IsoRouter can add delegate handlers into the window object of the browser. These are designed to make it easy to handle a tags and form submissions.
+Isorouter can add delegate handlers into the window object of the browser. These are designed to make it easy to handle a tags and form submissions.
 
 This is done by adding the options `var router = isoRouter({inject: true})` when creating the router instance.
 
@@ -165,7 +165,7 @@ Any submit event will be handled unless handled further down the dom with `stopP
 
 Click events on submit tags will be handled as per form tags.
 
-By default clicking links will cause a scroll reset (`scrollTo(0, 0)`) if you want to prevent this you can add `data-prevent-scroll-reset` attriute to links, for example
+By default clicking links will cause a scroll reset (`scrollTo(0, 0)`) if you want to prevent this you can add `data-prevent-scroll-reset` attribute to links, for example
 
     <a href="?limit=10" data-prevent-scroll-reset="true">More</a>
 

--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ Options:
 * locals: object passed to handler as `req.locals`
 * silent: trigger navigation without adding to pushstate
 * replace: navigate replacing the last item in pushstate (useful for redirects to)
+* preventScrollReset: prevents the scroll position resetting on navigation.
 
 `router.destroy()`
 
@@ -163,6 +164,12 @@ Any submit event will be handled unless handled further down the dom with `stopP
 `<input type="submit">` tags
 
 Click events on submit tags will be handled as per form tags.
+
+By default clicking links will cause a scroll reset (`scrollTo(0, 0)`) if you want to prevent this you can add `data-prevent-scroll-reset` attriute to links, for example
+
+    <a href="?limit=10" data-prevent-scroll-reset="true">More</a>
+
+
 
 ## Gotchas
 

--- a/browser.js
+++ b/browser.js
@@ -245,8 +245,10 @@ function go (path, opts) {
       path: url
     });
 
-    // Reset scroll position
-    window.scrollTo(0,0);
+    if(!opts.preventScrollReset) {
+      // Reset scroll position
+      window.scrollTo(0,0);
+    }
 
     // Iterate through the middlewares and routes
     next();

--- a/lib/dom_event_handler.js
+++ b/lib/dom_event_handler.js
@@ -93,9 +93,10 @@ module.exports = function (el) {
     // Ignore links with a target.
     if (!target.hasAttribute("target")) {
       var url = target.getAttribute("href");
+      var preventScrollReset = target.getAttribute("data-prevent-scroll-reset");
 
       // Only do isorouter if we find the route, otherwise do browser default
-      if (router.go(url)) {
+      if (router.go(url, {preventScrollReset: preventScrollReset})) {
         e.preventDefault();
       }
     }


### PR DESCRIPTION
I've added `data-prevent-scroll-reset` to prevent scroll from resetting on click.

This become useful for infinite scroll for example in a list where you have _5_ items you could just have to following to fetch _5_ more items without the jump of navigation

```
<a href="?limit=10" data-prevent-scroll-reset="true">More</a>
```

@oliverbrooks @ExPHAT thoughts?
