### PR TITLE
Fix for redirect options and get form submission

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -191,8 +191,8 @@ function go (path, opts) {
         silent: redirectOpts.silent,
         replace: redirectOpts.replace,
         redirect: shouldRedirect,
-        body: body,
-        locals: locals
+        body: redirectOpts.body || body,
+        locals: redirectOpts.locals || locals
       });
     }
   };

--- a/browser.js
+++ b/browser.js
@@ -155,8 +155,10 @@ function go (path, opts) {
     __id: this.reqIdx++,
     method: method,
     body: body,
+    protocol: window.location.protocol,
+    hostname: window.location.hostname,
     headers: {
-      host: parsedUrl.host,
+      host: window.location.host,
       cookie: document.cookie
     },
     locals: locals,

--- a/browser.js
+++ b/browser.js
@@ -155,6 +155,10 @@ function go (path, opts) {
     __id: this.reqIdx++,
     method: method,
     body: body,
+    headers: {
+      host: parsedUrl.host,
+      cookie: document.cookie
+    },
     locals: locals,
     originalUrl: url,
     path: parsedUrl.pathname,
@@ -245,7 +249,7 @@ function go (path, opts) {
       path: url
     });
 
-    if(!opts.preventScrollReset) {
+    if (!opts.preventScrollReset) {
       // Reset scroll position
       window.scrollTo(0,0);
     }

--- a/browser.js
+++ b/browser.js
@@ -155,7 +155,7 @@ function go (path, opts) {
     __id: this.reqIdx++,
     method: method,
     body: body,
-    protocol: window.location.protocol,
+    protocol: window.location.protocol.replace(":", ""),
     hostname: window.location.hostname,
     headers: {
       host: window.location.host,

--- a/lib/dom_event_handler.js
+++ b/lib/dom_event_handler.js
@@ -67,7 +67,10 @@ module.exports = function (el) {
 
     return router.go(Url.format(outUrl), {
       method: method,
-      body: data
+      body: data,
+      replace: target.getAttribute("data-isorouter-replace"),
+      silent: target.getAttribute("data-isorouter-silent"),
+      hard: target.getAttribute("data-isorouter-hard")
     });
   }
 

--- a/lib/dom_event_handler.js
+++ b/lib/dom_event_handler.js
@@ -51,21 +51,21 @@ module.exports = function (el) {
       method = data._method || urlParsed.query._method;
     }
 
+    var outUrl = {
+      protocol: urlParsed.protocol,
+      host: urlParsed.host,
+      pathname: urlParsed.pathname
+    };
+
     // Combine form data and url data taking form data in precidence
     if (method === "get" && urlParsed.query) {
       Object.keys(urlParsed.query).forEach(function (key) {
         data[key] = data[key] || urlParsed.query[key];
       });
+      outUrl.query = data;
     }
 
-    var outUrl = Url.format({
-      protocol: urlParsed.protocol,
-      host: urlParsed.host,
-      pathname: urlParsed.pathname,
-      query: data
-    });
-
-    return router.go(outUrl, {
+    return router.go(Url.format(outUrl), {
       method: method,
       body: data
     });

--- a/lib/dom_event_handler.js
+++ b/lib/dom_event_handler.js
@@ -51,24 +51,24 @@ module.exports = function (el) {
       method = data._method || urlParsed.query._method;
     }
 
-    if (method === "get") {
-      // Combine form data and url data taking form data in precidence
-      if (urlParsed.query) {
-        Object.keys(urlParsed.query).forEach(function (key) {
-          data[key] = data[key] || urlParsed.query[key];
-        });
-      }
-      url = Url.format({
-        pathname: urlParsed.pathname,
-        query: data
-      });
-      return router.go(url);
-    } else {
-      return router.go(url, {
-        method: method,
-        body: data
+    // Combine form data and url data taking form data in precidence
+    if (method === "get" && urlParsed.query) {
+      Object.keys(urlParsed.query).forEach(function (key) {
+        data[key] = data[key] || urlParsed.query[key];
       });
     }
+
+    var outUrl = Url.format({
+      protocol: urlParsed.protocol,
+      host: urlParsed.host,
+      pathname: urlParsed.pathname,
+      query: data
+    });
+
+    return router.go(outUrl, {
+      method: method,
+      body: data
+    });
   }
 
   delegate.on("submit", "form", function (e, target) {

--- a/lib/dom_event_handler.js
+++ b/lib/dom_event_handler.js
@@ -68,9 +68,9 @@ module.exports = function (el) {
     return router.go(Url.format(outUrl), {
       method: method,
       body: data,
-      replace: target.getAttribute("data-isorouter-replace"),
-      silent: target.getAttribute("data-isorouter-silent"),
-      hard: target.getAttribute("data-isorouter-hard")
+      replace: target.getAttribute("data-isorouter-replace") ? true : false,
+      silent: target.getAttribute("data-isorouter-silent") ? true : false,
+      hard: target.getAttribute("data-isorouter-hard") ? true : false
     });
   }
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "isorouter",
   "description": "Isomorphic express like router.",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "main": "./server.js",
   "browser": "./browser.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "isorouter",
   "description": "Isomorphic express like router.",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "main": "./server.js",
   "browser": "./browser.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "isorouter",
   "description": "Isomorphic express like router.",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "main": "./server.js",
   "browser": "./browser.js",
   "scripts": {


### PR DESCRIPTION
Sorry for combined PR, my branch had a few commits to fix issues which weren't submitted earlier.
1. When redirecting `res.redirect("/foo", 302, {locals: {flash: "FISH!"}})` the redirect options are passed into `router.go`.
2. When doing GET form submissions the form inputs are merged into the url querystring 
